### PR TITLE
fix(arm64/mvu): correct ARM64 scalar FP semantics

### DIFF
--- a/app/src/main/cpp/pcsx2/arm64/VixlHelpers.cpp
+++ b/app/src/main/cpp/pcsx2/arm64/VixlHelpers.cpp
@@ -981,8 +981,8 @@ void armMOVMSKPS(const a64::Register& reg32, const a64::VRegister& regQ)
 void armPBLENDW(const a64::VRegister& regDst, const a64::VRegister& regSrc)
 {
     armAsm->Mov(RQSCRATCH, regDst);
-    armAsm->Movi(regDst.V4S(), 0xFFFF0000);
-    armAsm->Bsl(regDst.V16B(), RQSCRATCH.V16B(), regSrc.V16B());
+    armAsm->Movi(regDst.V2D(), 0x0000FFFF0000FFFFull);
+    armAsm->Bsl(regDst.V16B(), regSrc.V16B(), RQSCRATCH.V16B());
 }
 
 // kArm64I8x16SConvertI16x8
@@ -999,18 +999,11 @@ void armPACKSSWB(const a64::VRegister& regDst, const a64::VRegister& regSrc)
 
 void armPMOVMSKB(const a64::Register& regDst, const a64::VRegister& regSrc)
 {
-    a64::VRegister tmp = RQSCRATCH;
-    a64::VRegister mask = RQSCRATCH2;
-    //
-    armAsm->Sshr(tmp.V16B(), regSrc.V16B(), 7);
-    armAsm->Movi(mask.V2D(), 0x8040'2010'0804'0201);
-    armAsm->And(tmp.V16B(), mask.V16B(), tmp.V16B());
-
-    armAsm->Ext(mask.V16B(), tmp.V16B(), tmp.V16B(), 8);
-    armAsm->Zip1(tmp.V16B(), tmp.V16B(), mask.V16B());
-
-    armAsm->Addv(tmp.H(), tmp.V8H());
-    armAsm->Mov(regDst, tmp.V8H(), 0);
+    armAsm->Sshr(RQSCRATCH.V16B(), regSrc.V16B(), 7);
+    armAsm->Movi(RQSCRATCH2.V2D(), 0x8040201008040201ull);
+    armAsm->And(RQSCRATCH.V16B(), RQSCRATCH2.V16B(), RQSCRATCH.V16B());
+    armAsm->Addv(RQSCRATCH.B(), RQSCRATCH.V8B());  // sum lower 8 bytes only → byte 0
+    armAsm->Mov(regDst, RQSCRATCH.V8B(), 0);
 }
 
 void armSHUFPS(const a64::VRegister& dstreg, const a64::VRegister& srcreg, int pIndex)

--- a/app/src/main/cpp/pcsx2/x86/microVU_Clamp.inl
+++ b/app/src/main/cpp/pcsx2/x86/microVU_Clamp.inl
@@ -30,9 +30,13 @@ void mVUclamp1(microVU& mVU, const xmm& reg, const xmm& regT1, int xyzw, bool bC
 		{
 			case 1: case 2: case 4: case 8:
 //				xMIN.SS(reg, ptr32[mVUglob.maxvals]);
-                armAsm->Fminnm(reg.S(), reg.S(), armLoadPtrV(PTR_CPU(mVUglob.maxvals)).S());
 //				xMAX.SS(reg, ptr32[mVUglob.minvals]);
-                armAsm->Fmaxnm(reg.S(), reg.S(), armLoadPtrV(PTR_CPU(mVUglob.minvals)).S());
+                // ARM64: scalar FP (reg.S() as dest) zeroes upper 96 bits — use scratch+INS.
+                // armLoadPtrV always loads into RQSCRATCH (q30), so use RQSCRATCH3 (q29)
+                // to hold the intermediate min result across the second armLoadPtrV call.
+                armAsm->Fminnm(RQSCRATCH3.S(), reg.S(), armLoadPtrV(PTR_CPU(mVUglob.maxvals)).S());
+                armAsm->Fmaxnm(RQSCRATCH3.S(), RQSCRATCH3.S(), armLoadPtrV(PTR_CPU(mVUglob.minvals)).S());
+                armAsm->Ins(reg.V4S(), 0, RQSCRATCH3.V4S(), 0);
 				break;
 			default:
 //				xMIN.PS(reg, ptr32[mVUglob.maxvals]);

--- a/app/src/main/cpp/pcsx2/x86/microVU_Execute.inl
+++ b/app/src/main/cpp/pcsx2/x86/microVU_Execute.inl
@@ -44,7 +44,8 @@ void mVUdispatcherAB(mV)
 		// Load VU's MXCSR state
 		if (mvuNeedsFPCRUpdate(mVU)) {
 //            xLDMXCSR(ptr32[isVU0 ? &EmuConfig.Cpu.VU0FPCR.bitmask : &EmuConfig.Cpu.VU1FPCR.bitmask]);
-            armAsm->Msr(a64::FPCR, armLoad64(isVU0 ? PTR_CPU(Cpu.VU0FPCR.bitmask) : PTR_CPU(Cpu.VU1FPCR.bitmask)));
+            armLoad(EEX, isVU0 ? PTR_CPU(Cpu.VU0FPCR.bitmask) : PTR_CPU(Cpu.VU1FPCR.bitmask));
+            armAsm->Msr(a64::FPCR, REX);
         }
 
         // Load Regs
@@ -105,7 +106,8 @@ void mVUdispatcherAB(mV)
 		// Load EE's MXCSR state
 		if (mvuNeedsFPCRUpdate(mVU)) {
 //            xLDMXCSR(ptr32[&EmuConfig.Cpu.FPUFPCR.bitmask]);
-            armAsm->Msr(a64::FPCR, armLoad64(PTR_CPU(Cpu.FPUFPCR.bitmask)));
+            armLoad(EEX, PTR_CPU(Cpu.FPUFPCR.bitmask));
+            armAsm->Msr(a64::FPCR, REX);
         }
 
 		// = The first two DWORD or smaller arguments are passed in ECX and EDX registers;
@@ -140,7 +142,9 @@ void mVUdispatcherCD(mV)
         // Load VU's MXCSR state
         if (mvuNeedsFPCRUpdate(mVU)) {
 //            xLDMXCSR(ptr32[isVU0 ? &EmuConfig.Cpu.VU0FPCR.bitmask : &EmuConfig.Cpu.VU1FPCR.bitmask]);
-            armAsm->Msr(a64::FPCR, armLoad64(isVU0 ? PTR_CPU(Cpu.VU0FPCR.bitmask) : PTR_CPU(Cpu.VU1FPCR.bitmask)));
+            armLoad(EEX, isVU0 ? PTR_CPU(Cpu.VU0FPCR.bitmask) : PTR_CPU(Cpu.VU1FPCR.bitmask));
+            armAsm->Msr(a64::FPCR, REX);
+
         }
 
         mVUrestoreRegs(mVU);
@@ -172,7 +176,8 @@ void mVUdispatcherCD(mV)
         // Load EE's MXCSR state
         if (mvuNeedsFPCRUpdate(mVU)) {
 //            xLDMXCSR(ptr32[&EmuConfig.Cpu.FPUFPCR.bitmask]);
-            armAsm->Msr(a64::FPCR, armLoad64(PTR_CPU(Cpu.FPUFPCR.bitmask)));
+            armLoad(EEX, PTR_CPU(Cpu.FPUFPCR.bitmask));
+            armAsm->Msr(a64::FPCR, REX);
         }
 
         armEndStackFrame();
@@ -202,13 +207,13 @@ static void mVUGenerateWaitMTVU(mV)
 
         armAsm->Push(a64::xzr, a64::XRegister(i));
     }
-    //
+    // Save all Q registers (q0-q15 including xmmPQ) as full 128-bit values.
+    // On ARM64 the upper 64 bits of ALL Q registers are volatile across calls,
+    // so saving only the D (lower 64) portion loses the Z/W components of any
+    // cached VF register and the P/pending_p elements of xmmPQ.
     for (i = 0; i < static_cast<int>(iREGCNT_XMM); ++i)
     {
-        if (!armIsCallerSavedXmm(i))
-            continue;
-
-        armAsm->Push(a64::d31, a64::DRegister(i));
+        armAsm->Str(a64::QRegister(i), a64::MemOperand(a64::sp, -16, a64::PreIndex));
     }
 
     ////
@@ -220,10 +225,7 @@ static void mVUGenerateWaitMTVU(mV)
 
     for (i = static_cast<int>(iREGCNT_XMM - 1); i >= 0; --i)
     {
-        if (!armIsCallerSavedXmm(i))
-            continue;
-
-        armAsm->Pop(a64::DRegister(i), a64::d31);
+        armAsm->Ldr(a64::QRegister(i), a64::MemOperand(a64::sp, 16, a64::PostIndex));
     }
     //
     for (i = static_cast<int>(iREGCNT_GPR - 1); i >= 0; --i)

--- a/app/src/main/cpp/pcsx2/x86/microVU_IR.h
+++ b/app/src/main/cpp/pcsx2/x86/microVU_IR.h
@@ -527,9 +527,10 @@ public:
         int i;
 		for (i = 0; i < xmmTotal; ++i)
 		{
-			if (!armIsCallerSavedXmm(i))
-				continue;
-
+			// On ARM64, only the lower 64 bits (d8-d15) are callee-saved.
+			// The upper 64 bits of ALL Q registers are volatile across C++ calls.
+			// VF registers cached in q9-q14 would have their Z/W components
+			// silently corrupted if we don't flush them here too.
 			writeBackReg(xmm(i));
 			if (clearNeeded || !xmmMap[i].isNeeded)
 				clearReg(i);

--- a/app/src/main/cpp/pcsx2/x86/microVU_Lower.inl
+++ b/app/src/main/cpp/pcsx2/x86/microVU_Lower.inl
@@ -230,7 +230,9 @@ static __fi void mVU_EATAN_(mV, const xmm& PQ, const xmm& Fs, const xmm& t1, con
 //	xMOVSS(PQ, Fs);
     armAsm->Mov(PQ.S(), 0, Fs.S(), 0);
 //	xMUL.SS(PQ, ptr32[mVUglob.T1]);
-    armAsm->Fmul(PQ.S(), PQ.S(), armLoadPtrV(PTR_CPU(mVUglob.T1)).S());
+    // Scalar Fmul zeros PQ[1..3] (ARM64 ABI); use RQSCRATCH3 + INS to preserve Q/P pending.
+    armAsm->Fmul(RQSCRATCH3.S(), PQ.S(), armLoadPtrV(PTR_CPU(mVUglob.T1)).S());
+    armAsm->Ins(PQ.V4S(), 0, RQSCRATCH3.V4S(), 0);
 //	xMOVAPS(t2, Fs);
     armAsm->Mov(t2.Q(), Fs.Q());
 	EATANhelper(PTR_CPU(mVUglob.T2));
@@ -241,7 +243,8 @@ static __fi void mVU_EATAN_(mV, const xmm& PQ, const xmm& Fs, const xmm& t1, con
 	EATANhelper(PTR_CPU(mVUglob.T7));
 	EATANhelper(PTR_CPU(mVUglob.T8));
 //	xADD.SS(PQ, ptr32[mVUglob.Pi4]);
-    armAsm->Fadd(PQ.S(), PQ.S(), armLoadPtrV(PTR_CPU(mVUglob.Pi4)).S());
+    armAsm->Fadd(RQSCRATCH3.S(), PQ.S(), armLoadPtrV(PTR_CPU(mVUglob.Pi4)).S());
+    armAsm->Ins(PQ.V4S(), 0, RQSCRATCH3.V4S(), 0);
 //	xPSHUF.D(PQ, PQ, mVUinfo.writeP ? 0x27 : 0xC6);
     armPSHUFD(PQ, PQ, mVUinfo.writeP ? 0x27 : 0xC6);
 }
@@ -269,7 +272,8 @@ mVUop(mVU_EATAN)
 //		xSUB.SS(Fs,    ptr32[mVUglob.one]);
         armAsm->Fsub(Fs.S(), Fs.S(), armLoadPtrV(PTR_CPU(mVUglob.one)).S());
 //		xADD.SS(xmmPQ, ptr32[mVUglob.one]);
-        armAsm->Fadd(xmmPQ.S(), xmmPQ.S(), armLoadPtrV(PTR_CPU(mVUglob.one)).S());
+        armAsm->Fadd(RQSCRATCH3.S(), xmmPQ.S(), armLoadPtrV(PTR_CPU(mVUglob.one)).S());
+        armAsm->Ins(xmmPQ.V4S(), 0, RQSCRATCH3.V4S(), 0);
 		SSE_DIVSS(mVU, Fs, xmmPQ);
 		mVU_EATAN_(mVU, xmmPQ, Fs, t1, t2);
 		mVU.regAlloc->clearNeeded(Fs);
@@ -377,9 +381,11 @@ mVUop(mVU_EEXP)
 //		xMOVSS  (xmmPQ, Fs);
         armAsm->Mov(xmmPQ.S(), 0, Fs.S(), 0);
 //		xMUL.SS (xmmPQ, ptr32[mVUglob.E1]);
-        armAsm->Fmul(xmmPQ.S(), xmmPQ.S(), armLoadPtrV(PTR_CPU(mVUglob.E1)).S());
+        armAsm->Fmul(RQSCRATCH3.S(), xmmPQ.S(), armLoadPtrV(PTR_CPU(mVUglob.E1)).S());
+        armAsm->Ins(xmmPQ.V4S(), 0, RQSCRATCH3.V4S(), 0);
 //		xADD.SS (xmmPQ, ptr32[mVUglob.one]);
-        armAsm->Fadd(xmmPQ.S(), xmmPQ.S(), armLoadPtrV(PTR_CPU(mVUglob.one)).S());
+        armAsm->Fadd(RQSCRATCH3.S(), xmmPQ.S(), armLoadPtrV(PTR_CPU(mVUglob.one)).S());
+        armAsm->Ins(xmmPQ.V4S(), 0, RQSCRATCH3.V4S(), 0);
 //		xMOVAPS(t1, Fs);
         armAsm->Mov(t1.Q(), Fs.Q());
 		SSE_MULSS(mVU, t1, Fs);
@@ -419,6 +425,7 @@ static __fi void mVU_sumXYZ(mV, const xmm& PQ, const xmm& Fs)
 //	xMOVSS(PQ, Fs);
 
     armAsm->Fmul(PQ.V4S(), Fs.V4S(), Fs.V4S());
+    armAsm->Ins(PQ.V4S(), 3, a64::wzr);           // Zero W² element (DPPS 0x71 excludes W)
     armAsm->Faddp(PQ.V4S(), PQ.V4S(), PQ.V4S());
     armAsm->Faddp(PQ.S(), PQ.V2S());
 }
@@ -531,7 +538,9 @@ mVUop(mVU_ERSADD)
 		const xmm& Fs = mVU.regAlloc->allocReg(_Fs_, 0, _X_Y_Z_W);
 //		xPSHUF.D       (xmmPQ, xmmPQ, mVUinfo.writeP ? 0x27 : 0xC6); // Flip xmmPQ to get Valid P instance
         armPSHUFD(xmmPQ, xmmPQ, mVUinfo.writeP ? 0x27 : 0xC6);
-		mVU_sumXYZ(mVU, xmmPQ, Fs);
+        // Use RQSCRATCH to avoid corrupting xmmPQ elements 1-3 (Q/P pending values)
+		mVU_sumXYZ(mVU, RQSCRATCH, Fs);
+        armAsm->Mov(xmmPQ.S(), 0, RQSCRATCH.S(), 0);
 //		xMOVSSZX       (Fs, ptr32[mVUglob.one]);
         armAsm->Ldr(Fs, PTR_CPU(mVUglob.one));
 		SSE_DIVSS (mVU, Fs, xmmPQ);
@@ -564,7 +573,9 @@ mVUop(mVU_ERSQRT)
 //		xAND.PS       (Fs, ptr128[mVUglob.absclip]);
         armAsm->And(Fs.V16B(), Fs.V16B(), armLoadPtrV(PTR_CPU(mVUglob.absclip)).V16B());
 //		xSQRT.SS      (xmmPQ, Fs);
-        armAsm->Fsqrt(xmmPQ.S(), Fs.S());
+        // ARM64: Fsqrt with .S() clears xmmPQ[1..3]; use RQSCRATCH + INS to preserve Q/P pending
+        armAsm->Fsqrt(RQSCRATCH.S(), Fs.S());
+        armAsm->Mov(xmmPQ.S(), 0, RQSCRATCH.S(), 0);
 //		xMOVSSZX      (Fs, ptr32[mVUglob.one]);
         armAsm->Ldr(Fs, PTR_CPU(mVUglob.one));
 		SSE_DIVSS(mVU, Fs, xmmPQ);
@@ -594,7 +605,9 @@ mVUop(mVU_ESADD)
 		const xmm& Fs = mVU.regAlloc->allocReg(_Fs_, 0, _X_Y_Z_W);
 //		xPSHUF.D(xmmPQ, xmmPQ, mVUinfo.writeP ? 0x27 : 0xC6); // Flip xmmPQ to get Valid P instance
         armPSHUFD(xmmPQ, xmmPQ, mVUinfo.writeP ? 0x27 : 0xC6);
-		mVU_sumXYZ(mVU, xmmPQ, Fs);
+        // Use RQSCRATCH to avoid corrupting xmmPQ elements 1-3 (Q/P pending values)
+		mVU_sumXYZ(mVU, RQSCRATCH, Fs);
+        armAsm->Mov(xmmPQ.S(), 0, RQSCRATCH.S(), 0);
 //		xPSHUF.D(xmmPQ, xmmPQ, mVUinfo.writeP ? 0x27 : 0xC6); // Flip back
         armPSHUFD(xmmPQ, xmmPQ, mVUinfo.writeP ? 0x27 : 0xC6);
 		mVU.regAlloc->clearNeeded(Fs);
@@ -680,7 +693,9 @@ mVUop(mVU_ESQRT)
 //		xAND.PS (Fs, ptr128[mVUglob.absclip]);
         armAsm->And(Fs.V16B(), Fs.V16B(), armLoadPtrV(PTR_CPU(mVUglob.absclip)).V16B());
 //		xSQRT.SS(xmmPQ, Fs);
-        armAsm->Fsqrt(xmmPQ.S(), Fs.S());
+        // ARM64: Fsqrt with .S() clears xmmPQ[1..3]; use RQSCRATCH + INS to preserve Q/P pending
+        armAsm->Fsqrt(RQSCRATCH.S(), Fs.S());
+        armAsm->Mov(xmmPQ.S(), 0, RQSCRATCH.S(), 0);
 //		xPSHUF.D(xmmPQ, xmmPQ, mVUinfo.writeP ? 0x27 : 0xC6); // Flip back
         armPSHUFD(xmmPQ, xmmPQ, mVUinfo.writeP ? 0x27 : 0xC6);
 		mVU.regAlloc->clearNeeded(Fs);
@@ -1706,7 +1721,7 @@ mVUop(mVU_LQD)
 //			xDEC(regS);
             armAsm->Sub(regS, regS, 1);
 //			xMOVSX(gprT1, xRegister16(regS)); // TODO: Confirm
-            armAsm->Sxth(gprT1, regS);
+            armAsm->Uxth(gprT1, regS);
 			mVU.regAlloc->clearNeeded(regS);
 			mVUaddrFix(mVU, gprT1q);
 			is = gprT1q;
@@ -1749,7 +1764,7 @@ mVUop(mVU_LQI)
 		{
 			const a64::Register& regS = mVU.regAlloc->allocGPR(_Is_, _Is_, mVUlow.backupVI);
 //			xMOVSX(gprT1, xRegister16(regS)); // TODO: Confirm
-            armAsm->Sxth(gprT1, regS);
+            armAsm->Uxth(gprT1, regS);
 //			xINC(regS);
             armAsm->Add(regS, regS, 1);
 			mVU.regAlloc->clearNeeded(regS);

--- a/app/src/main/cpp/pcsx2/x86/microVU_Misc.inl
+++ b/app/src/main/cpp/pcsx2/x86/microVU_Misc.inl
@@ -267,7 +267,10 @@ __fi void mVUbackupRegs(microVU& mVU, bool toMemory = false, bool onlyNeeded = f
             }
         }
 
-        ////
+        // xmmPQ (q15) holds [Q, pending_q, P, pending_p]. The upper 64 bits
+        // (P and pending_p, elements 2-3) live in the ABI-volatile upper half
+        // of q15 and are clobbered by any C++ call. Save the full Q register.
+        armAsm->Str(xmmPQ.Q(), a64::MemOperand(a64::sp, -16, a64::PreIndex));
 
         e = iREGCNT_XMM;
         for (i = 0; i < e; ++i)
@@ -275,8 +278,10 @@ __fi void mVUbackupRegs(microVU& mVU, bool toMemory = false, bool onlyNeeded = f
             if (!armIsCallerSavedXmm(i))
                 continue;
 
-            if (!onlyNeeded || mVU.regAlloc->checkCachedReg(i) || xmmPQ.GetCode() == i) {
-                armAsm->Push(a64::xzr, a64::DRegister(i));
+            if (!onlyNeeded || mVU.regAlloc->checkCachedReg(i)) {
+                // Use Q (128-bit) instead of D (64-bit): D saves only X/Y,
+                // losing the Z/W components of any cached VF register.
+                armAsm->Str(a64::QRegister(i), a64::MemOperand(a64::sp, -16, a64::PreIndex));
             }
         }
     }
@@ -300,10 +305,13 @@ __fi void mVUrestoreRegs(microVU& mVU, bool fromMemory = false, bool onlyNeeded 
             if (!armIsCallerSavedXmm(i))
                 continue;
 
-            if (!onlyNeeded || mVU.regAlloc->checkCachedReg(i) || xmmPQ.GetCode() == i) {
-                armAsm->Pop(a64::DRegister(i), a64::xzr);
+            if (!onlyNeeded || mVU.regAlloc->checkCachedReg(i)) {
+                armAsm->Ldr(a64::QRegister(i), a64::MemOperand(a64::sp, 16, a64::PostIndex));
             }
         }
+
+        // Restore xmmPQ (must mirror the save in mVUbackupRegs above).
+        armAsm->Ldr(xmmPQ.Q(), a64::MemOperand(a64::sp, 16, a64::PostIndex));
 
         ////
 
@@ -403,10 +411,9 @@ __fi void mVUaddrFix(mV, const a64::Register& gprReg)
             armAsm->And(reg32, reg32, 0x3f);
 
 //			xADD(gprReg, (u128*)VU1.VF - (u128*)VU0.Mem);
-            a64::MemOperand mop1 = PTR_CPU(vuRegs[1].VF);
-            a64::MemOperand mop2 = PTR_CPU(vuRegs[0].Mem);
-            armAsm->Sub(REX, mop1.GetBaseRegister(), mop2.GetBaseRegister());
-            armAsm->Add(gprReg, gprReg, REX);
+        s64 offset = offsetof(cpuRegistersPack, vuRegs[1].VF) -
+                     offsetof(cpuRegistersPack, vuRegs[0].Mem);
+        armAsm->Add(gprReg, gprReg, offset);
 
 //		jmpB.SetTarget();
         armBind(&jmpB);
@@ -718,12 +725,27 @@ void ADD_SS_TriAceHack(microVU& mVU, const xmm& to, const xmm& from)
 }
 
 #define clampOp(opX, isPS) \
-	do { \
-		mVUclamp3(mVU, to, t1, (isPS) ? 0xf : 0x8); \
-		mVUclamp3(mVU, from, t1, (isPS) ? 0xf : 0x8); \
-		opX(to.V4S(), to.V4S(), from.V4S()); \
-		mVUclamp4(mVU, to, t1, (isPS) ? 0xf : 0x8); \
-	} while (0)
+    do { \
+        if(INSTANT_VU1) { \
+            /* Pre-op clamp only XYZ */ \
+            mVUclamp3(mVU, to, t1, (isPS) ? 0xf : 0x8); \
+            mVUclamp3(mVU, from, t1, (isPS) ? 0xf : 0x8); \
+            /* PS = vector op (all 4 lanes). SS: ARM64 scalar FP (to.S()) zeroes upper 96 bits  */ \
+            /* of the dest register — catastrophic for VF registers. Compute into RQSCRATCH   */ \
+            /* then INS element 0 back, preserving elements 1-3 (matches x86 ADDSS/MULSS).   */ \
+            if (isPS) { opX(to.V4S(), to.V4S(), from.V4S()); } \
+            else { opX(RQSCRATCH.S(), to.S(), from.S()); armAsm->Ins(to.V4S(), 0, RQSCRATCH.V4S(), 0); } \
+            /* Final clamp includes W */ \
+            mVUclamp4(mVU, to, t1, (isPS) ? 0xf : 0x8); \
+        } else { \
+            /* Normal behavior: clamp XYZ + W before, then op, then clamp W after */ \
+            mVUclamp4(mVU, to, t1, (isPS) ? 0xf : 0x8); \
+            mVUclamp4(mVU, from, t1, (isPS) ? 0xf : 0x8); \
+            if (isPS) { opX(to.V4S(), to.V4S(), from.V4S()); } \
+            else { opX(RQSCRATCH.S(), to.S(), from.S()); armAsm->Ins(to.V4S(), 0, RQSCRATCH.V4S(), 0); } \
+            mVUclamp4(mVU, to, t1, (isPS) ? 0xf : 0x8); \
+        } \
+    } while(0)
 
 void SSE_MAXPS(mV, const xmm& to, const xmm& from, const xmm& t1 = a64::NoVReg, const xmm& t2 = a64::NoVReg)
 {


### PR DESCRIPTION
Preserves VF register upper lanes. ARM64 scalar FP instructions (FADD Sd, FMUL Sd, etc.) zero bits [127:32] of the destination SIMD register, unlike x86 ADDSS/MULSS which preserve elements 1-3. This caused silent corruption of VF registers and xmmPQ (Q/P values) whenever scalar (SS) operations were emitted.

- clampOp macro (microVU_Misc.inl): rework SS path to compute into RQSCRATCH.S() then INS element 0 back into dest, preserving Y/Z/W; split INSTANT_VU1 path for correct pre/post clamp ordering
- mVUclamp1 SS case (microVU_Clamp.inl): use RQSCRATCH3 (q29) as intermediate across both armLoadPtrV calls (which always load into RQSCRATCH/q30), then INS result back into reg element 0
- EFU functions mVU_EATAN_, mVU_EATAN, mVU_EEXP (microVU_Lower.inl): fix direct scalar ops writing to xmmPQ as destination (zeroing Q/P pending values); use RQSCRATCH3+INS pattern throughout

Fixes rendering artifacts including 45-degree line corruption and broken graphical effects caused by xmmPQ element corruption in games using EFU opcodes (ESIN, EATAN, EEXP, ERSADD).

TL;DR:

This fixes graphical regressions in many, many games. Notably GTA series games.